### PR TITLE
Remove card update form from UM dashboard

### DIFF
--- a/includes/UltimateMember.php
+++ b/includes/UltimateMember.php
@@ -143,7 +143,6 @@ class UltimateMember {
 
 		<?php
 		echo do_shortcode( '[subscription_details]' );
-		echo do_shortcode( '[rcp_update_card]' );
 	}
 
 }


### PR DESCRIPTION
Card update form is not compatible with the UM form structure. Fixes #5.